### PR TITLE
Explicitly specify location of `java` via $JAVA_HOME

### DIFF
--- a/nexus-start.sh
+++ b/nexus-start.sh
@@ -14,7 +14,7 @@ ln -s ${P2_PLUGIN_PATH}/${P2_BRIDGE_PLUGIN} ${NEXUS_PLUGIN_PATH}/${P2_BRIDGE_PLU
 ln -s ${P2_PLUGIN_PATH}/${P2_REPO_PLUGIN}   ${NEXUS_PLUGIN_PATH}/${P2_REPO_PLUGIN}
 
 echo "Start up nexus."
-exec java \
+exec ${JAVA_HOME}/bin/java \
   -Dnexus-work=${SONATYPE_WORK} -Dnexus-webapp-context-path=${CONTEXT_PATH} \
   -Xms${MIN_HEAP} -Xmx${MAX_HEAP} \
   -cp 'conf/:lib/*' \


### PR DESCRIPTION
Reflect [change in upstream `sonatype/docker-nexus`](https://github.com/sonatype/docker-nexus/commit/65cb7b2c2459495b7078bb651ac8be7dd8d162a8#diff-214811c8ae5670489ae78f89c88f7376) to explicitly specify location of `java`
